### PR TITLE
Refactor TasksViewModel and update MainWindow bindings

### DIFF
--- a/TaskManagerApp/TaskManagerApp/ViewModels/TasksViewModel.cs
+++ b/TaskManagerApp/TaskManagerApp/ViewModels/TasksViewModel.cs
@@ -53,25 +53,6 @@ public partial class TasksViewModel : BaseViewModel
     return LoadComments();
   }
 
-  //async Task SearchComment()
-  //{
-  //  if(string.IsNullOrWhiteSpace(SearchText) && SelectedTask is null)
-  //    Comments.Clear();
-  //  SelectedTask = null;
-  //  if (string.IsNullOrWhiteSpace(SearchText))
-  //    return;
-  //  try
-  //  {
-  //    var result = await TasksContextService.Execute(c => c.GetComments(f => f.Comment = SearchText));
-  //    foreach (var comment in result)
-  //      Comments.Add(comment);
-  //  }
-  //  catch (Exception ex)
-  //  {
-  //    MessageBox.Show($"Error searching comments: {ex.Message}", "Search Error", MessageBoxButton.OK, MessageBoxImage.Error);
-  //  }
-  //}
-
   [RelayCommand]
   void DoubleClick(object? param)
   {
@@ -203,11 +184,6 @@ public partial class TasksViewModel : BaseViewModel
           IsGlobalSearch = false;
         CommentFilter.TaskId = SelectedTask?.Id;
         await LoadComments();
-        return;
-
-      case nameof(SelectedComment):
-        // TODO: Handle selected comment change if needed
-
         return;
 
       case nameof(SearchText):

--- a/TaskManagerApp/TaskManagerApp/Windows/MainWindow.xaml
+++ b/TaskManagerApp/TaskManagerApp/Windows/MainWindow.xaml
@@ -70,7 +70,7 @@
                   <ControlTemplate TargetType="ListBoxItem">
                     <views:CardRowView
                       x:Name="Bd"
-                      DoubleClickCommand="{Binding DataContext.DoubleClickCommand, RelativeSource={RelativeSource AncestorType=Page}}"
+                      DoubleClickCommand="{Binding DataContext.DoubleClickCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                       Background="#1F2421"
                       Foreground="White"
                       Cursor="Hand"
@@ -246,7 +246,7 @@
                   <ControlTemplate TargetType="ListBoxItem">
                     <views:CardRowView
                       x:Name="Bd"
-                      DoubleClickCommand="{Binding DataContext.DoubleClickCommand, RelativeSource={RelativeSource AncestorType=Page}}"
+                      DoubleClickCommand="{Binding DataContext.DoubleClickCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                       Background="#1F2421"
                       Foreground="White"
                       Cursor="Hand"
@@ -323,7 +323,7 @@
       <Button
         Margin="10,1"
         Padding="10,5"
-        Content="New Comment"
+        Content="New Task"
         Command="{Binding NewTaskCommand}"/>
     </StackPanel>
 

--- a/TaskManagerApp/TaskManagerApp/Windows/MainWindow.xaml.cs
+++ b/TaskManagerApp/TaskManagerApp/Windows/MainWindow.xaml.cs
@@ -22,13 +22,4 @@ public partial class MainWindow
 
   private async void Filter_SelectedDateChanged(object sender, SelectionChangedEventArgs e) =>
     await ViewModel.CommentFilterChanged();
-
-  private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
-  {
-    if (e.ClickCount == 2)
-      WindowState = (WindowState == WindowState.Normal)
-                    ? WindowState.Maximized
-                    : WindowState.Normal;
-    else DragMove();
-  }
 }


### PR DESCRIPTION
- Removed the `SearchComment` method from `TasksViewModel`.
- Commented out handling for `SelectedComment` property changes.
- Updated `DoubleClickCommand` binding to reference `Window`.
- Changed button content from "New Comment" to "New Task".
- Removed `TitleBar_MouseLeftButtonDown` event handler.